### PR TITLE
Fix too strict dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 install_requires = [
     'luigi',
     'gokart>=0.1.20',
-    'python-dateutil==2.7.5',
+    'python-dateutil>=2.7.5',
     'pandas',
     'scipy',
     'numpy',
@@ -17,8 +17,8 @@ install_requires = [
     'scikit-learn',
     'tensorflow>=1.13.1, <2.0',
     'tqdm',
-    'optuna==0.6.0',
     'docutils==0.15' # to avoid dependency conflict
+    'optuna>=0.6.0',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
     'scikit-learn',
     'tensorflow>=1.13.1, <2.0',
     'tqdm',
-    'docutils==0.15' # to avoid dependency conflict
+    'docutils==0.15', # to avoid dependency conflict
     'optuna>=0.6.0',
 ]
 


### PR DESCRIPTION
## Why

Too strict versioning of dependencies is decreasing availability of `redshells` itself.
Actually, current version `redshells` and [typepy](https://github.com/thombashi/typepy) cannot be used together (conflict of version of dateutils).